### PR TITLE
Allow for different issuer specifiers in OpenAM 12 and 13

### DIFF
--- a/cb-basic.html
+++ b/cb-basic.html
@@ -15,7 +15,7 @@
 !
 ! MPL 2.0 HEADER END
 !
-!     Copyright 2013-2014 ForgeRock AS
+!     Copyright 2013-2015 ForgeRock AS.
 !
 -->
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -108,7 +108,8 @@
                         }
 
                         // Validate id_token.
-                        if (payload.iss != server + openam) {
+                        // In 12, issuer path is /openam. In 13, issuer path is /openam/oauth2.
+                        if (payload.iss.lastIndexOf(server + openam, 0) !== 0) { // ~ startsWith
                             $("#info").html("Invalid id_token issuer: "
                                     + payload.iss);
                             return;

--- a/cb-implicit.html
+++ b/cb-implicit.html
@@ -15,7 +15,7 @@
 !
 ! MPL 2.0 HEADER END
 !
-!     Copyright 2013-2014 ForgeRock AS
+!     Copyright 2013-2015 ForgeRock AS.
 !
 -->
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -102,7 +102,8 @@
                 return;
             }
 
-            if (payload.iss != server + openam) {
+            // In 12, issuer path is /openam. In 13, issuer path is /openam/oauth2.
+            if (payload.iss.lastIndexOf(server + openam, 0) !== 0) { // ~ startsWith
                 $("#info").html("Invalid id_token issuer: " + payload.iss);
                 return;
             }


### PR DESCRIPTION
This patch fixes a failure to validate the ID token with OpenAM 13.

In OpenAM 12, the issuer path ends in at the base deployment path,
such as `/openam`.

In OpenAM 13, the issuer path ends in the base deployment path,
plus `/oauth2`, such as `/openam/oauth2`.

The workaround here is a little too lenient:
just check that the issuer starts with the correct path.