### PR TITLE
Issue #8 Add client_name for dynamic registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OpenAM 11.0.0 and later.
 
 The examples are not secure. Instead they are completely transparent,
 showing the requests and the steps for the Basic and Implicit Profiles,
-showing how to register a client dynamically,
+showing how to register with OpenID Connect Dynamic Client Registration,
 and showing OpenAM as OP and Authenticator for GSMA Mobile Connect.
 (Mobile Connect support requires OpenAM 12 or later.)
 
@@ -23,4 +23,4 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-Copyright 2013-2014 ForgeRock AS
+Copyright 2013-2015 ForgeRock AS.

--- a/register.html
+++ b/register.html
@@ -15,7 +15,7 @@
 !
 ! MPL 2.0 HEADER END
 !
-!     Copyright 2013-2014 ForgeRock AS
+!     Copyright 2013-2015 ForgeRock AS.
 !
 -->
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -59,10 +59,26 @@ $("#form").html(
 );
 </script>
 
-<p style="clear: both;">For dynamic registration you need an access token to
+<p style="clear: both;">For dynamic registration you might need an access token to
     write the configuration to OpenAM by HTTP POST. To obtain the access token,
     register an initial client statically after creating OpenID Connect
     provider, and then obtain the access token.</p>
+
+<blockquote>
+<h4>Tip</h4>
+<p>
+  In recent versions of OpenAM,
+  the console page for the OAuth2 Provider service configuration lets you enable
+  <strong>Allow Open Dynamic Client Registration</strong>,
+  so that no access token is required to register dynamically.
+</p>
+
+<p>
+  If you have enabled <strong>Allow Open Dynamic Client Registration</strong>,
+  then there is no need to get an access token.
+  Just click the Submit button.
+</p>
+</blockquote>
 
 <p>For example, if you register an OAuth 2.0 client in the top-level realm
     with name <code>myClientID</code> and client secret <code>password</code>,
@@ -95,7 +111,7 @@ $("#command").html(
     $("#form").submit(function () {
 
         var baseUrl = $("#baseUrl").val();
-        var configurationUrl = baseUrl + "/.well-known/openid-configuration";
+        var configurationUrl = baseUrl + "/oauth2/.well-known/openid-configuration";
         var registrationUrl = baseUrl + "/oauth2/connect/register"; // Default
         /*
          * Dynamic registration requires an access token from the provider
@@ -122,13 +138,16 @@ $("#command").html(
                         url: registrationUrl,
                         type: "POST",
                         beforeSend: function (xhr) {
+                          if (bearerToken) {
                             xhr.setRequestHeader(
                                     "Authorization", "Bearer " + bearerToken);
+                          }
                         },
                         dataType: "json",
                         contentType: "application/json",
                         data: JSON.stringify({
-                            "redirect_uris": redirect_uris
+                            "redirect_uris": redirect_uris,
+                            "client_name": "Dynamically Registered Client"
                         })
                     }).done(function (data) {
                                 $("#info").html(


### PR DESCRIPTION
This patch adds a `client_name` for dynamic registration.

It also takes advantage of a setting in OpenAM
that makes it unnecessary to get an access token before registering.

This is an example of a Registration Response:
    
    {
      "default_max_age_enabled": false,
      "subject_type": "public",
      "default_max_age": 1,
      "application_type": "web",
      "jwt_token_lifetime": 0,
      "registration_client_uri": "http://openam.example.com:8088/openam/oauth2/connect/register?client_id=9540e9cc-c492-4142-b7f6-aecd66523847",
      "client_type": "Confidential",
      "redirect_uris": [
        "http://openam.example.com:8088/openid/cb-basic.html",
        "http://openam.example.com:8088/openid/cb-implicit.html"
      ],
      "registration_access_token": "c5063095-63aa-415d-8a78-22f6a7cbf094",
      "client_id": "9540e9cc-c492-4142-b7f6-aecd66523847",
      "token_endpoint_auth_method": "client_secret_basic",
      "public_key_selector": "x509",
      "client_secret_expires_at": 0,
      "access_token_lifetime": 0,
      "refresh_token_lifetime": 0,
      "authorization_code_lifetime": 0,
      "scopes": [
        "address",
        "phone",
        "openid",
        "profile",
        "email"
      ],
      "client_secret": "6edaa85f-da51-473e-9df1-91ad7b154631",
      "client_name": "Dynamically Registered Client",
      "id_token_signed_response_alg": "HS256",
      "response_types": [
        "code"
      ]
    }